### PR TITLE
Allow to fetch CCP repos through SSH, expose services on external IP

### DIFF
--- a/ccp/control.sls
+++ b/ccp/control.sls
@@ -31,6 +31,24 @@ ccp_repos_dir:
   - require:
     - user: ccp_user
 
+ccp_ssh_dir:
+  file.directory:
+  - names:
+    - {{ control.dir.base }}/.ssh/
+  - mode: 700
+  - makedirs: true
+  - user: ccp
+  - require:
+    - user: ccp_user
+
+ccp_ssh_key:
+  cmd.run:
+  - name: ssh-keygen -q -N '' -f /srv/ccp/.ssh/id_rsa
+  - user: ccp
+  - unless: test -f /srv/ccp/.ssh/id_rsa
+  - require:
+    - file: ccp_ssh_dir
+
 ccp_log_dir:
   file.directory:
   - names:
@@ -77,5 +95,7 @@ ccp_validate:
   - user: ccp
   - watch:
     - file: ccp_config
+  - require:
+    - cmd: ccp_ssh_key
 
 {%- endif %}

--- a/ccp/control.sls
+++ b/ccp/control.sls
@@ -49,6 +49,14 @@ ccp_ssh_key:
   - require:
     - file: ccp_ssh_dir
 
+ccp_github_known_hosts:
+  ssh_known_hosts.present:
+  - user: ccp
+  - name: github.com
+  - fingerprint: 16:27:ac:a5:76:28:2d:36:63:1b:56:4d:eb:df:a6:48
+  - require:
+    - file: ccp_ssh_dir
+
 ccp_log_dir:
   file.directory:
   - names:
@@ -97,5 +105,6 @@ ccp_validate:
     - file: ccp_config
   - require:
     - cmd: ccp_ssh_key
+    - ssh_known_hosts: ccp_github_known_hosts
 
 {%- endif %}

--- a/ccp/files/ccp.yaml
+++ b/ccp/files/ccp.yaml
@@ -6,6 +6,12 @@ kubernetes:
   key_file: null
   namespace: {{ control.get('namespace', 'ccp') }}
   server: {{ control.kubernetes.get('protocol', 'http') }}://{{ control.kubernetes.host }}:{{ control.kubernetes.port }}
+{%- if control.expose_services and control.kubernetes.get('external_ip') %}
+  external_ips:
+    {%- for service in control.expose_services %}
+    {{ service }}: [{{ control.kubernetes.external_ip }}]
+    {%- endfor %}
+{%- endif %}
 verbose_level: 1
 log_file: /var/log/ccp/ccp.log
 debug: {{ control.debug }}

--- a/ccp/map.jinja
+++ b/ccp/map.jinja
@@ -24,6 +24,7 @@ Debian:
   sources: {}
   files: {}
   url: {}
+  expose_services: {}
 {%- endload %}
 
 {%- set control = salt['grains.filter_by'](base_defaults, merge=salt['pillar.get']('ccp:control')) %}


### PR DESCRIPTION
We need to fetch some CCP repos from private GitHub repos, so we need to generate SSH key and add GitHub key to known_hosts.

We also need to access some CCP services from outside of Kubernetes cluster, so we need to expose them via external IP.